### PR TITLE
feat: persistent collapsible task lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can download a prebuilt installer for chron on the [releases page](https://g
 ### Building from source
 
 1. Install the prerequisites:
-   1. [NodeJS 20](https://nodejs.org/en/download/)
+   1. [NodeJS 24](https://nodejs.org/en/download/)
    2. [Tauri 2.0](https://tauri.app/start/prerequisites/)
 2. Clone the repository. Change directory into the repository root.
 3. Install the dependencies:

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "next-themes";
 import { SidebarProvider, SidebarTrigger } from "@chron/components/ui/sidebar";
 import ChronSidebar from "@chron/components/chron/sidebar";
 import { TimerProvider } from "@chron/components/chron/timer-context";
+import { SettingsProvider } from "../components/chron/settings-context";
 
 export const metadata: Metadata = {
   title: "chron",
@@ -24,17 +25,19 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <TimerProvider>
-            <SidebarProvider defaultOpen={false}>
-              <ChronSidebar />
-              <main className="w-screen p-2">
-                <div className="flex flex-col gap-2">
-                  <SidebarTrigger />
-                  {children}
-                </div>
-              </main>
-            </SidebarProvider>
-          </TimerProvider>
+          <SettingsProvider>
+            <TimerProvider>
+              <SidebarProvider defaultOpen={false}>
+                <ChronSidebar />
+                <main className="w-screen p-2">
+                  <div className="flex flex-col gap-2">
+                    <SidebarTrigger />
+                    {children}
+                  </div>
+                </main>
+              </SidebarProvider>
+            </TimerProvider>
+          </SettingsProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,7 +36,7 @@ export default function Dashboard() {
         dailyHour,
         dailyMinute,
         weeklyDay,
-        closed: false,
+        open: true,
       };
 
       setGames((prev) => prev.concat([newItem]));

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,6 +36,7 @@ export default function Dashboard() {
         dailyHour,
         dailyMinute,
         weeklyDay,
+        closed: false,
       };
 
       setGames((prev) => prev.concat([newItem]));

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -18,9 +18,11 @@ import {
 import { Switch } from "@chron/components/ui/switch";
 import { Label } from "@chron/components/ui/label";
 import { useSettings } from "@chron/components/chron/settings-context";
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export default function Settings() {
+  const [isClient, setIsClient] = useState(false);
+
   const { setTheme } = useTheme();
   const { gameSettings, setGameSettings } = useSettings();
 
@@ -31,51 +33,57 @@ export default function Settings() {
     [setGameSettings]
   );
 
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
   return (
     <div className="flex flex-col gap-2 px-7">
-      <Accordion
-        type="multiple"
-        className="w-full"
-        defaultValue={["app-settings", "game-settings"]}
-      >
-        <AccordionItem value="app-settings">
-          <AccordionTrigger>App Settings</AccordionTrigger>
-          <AccordionContent className="flex flex-row items-center gap-4">
-            <div>Theme</div>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="outline" size="icon">
-                  <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-                  <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-                  <span className="sr-only">Toggle Theme</span>
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => setTheme("light")}>
-                  Light
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setTheme("dark")}>
-                  Dark
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setTheme("system")}>
-                  System
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </AccordionContent>
-        </AccordionItem>
-        <AccordionItem value="game-settings">
-          <AccordionTrigger>Game Settings</AccordionTrigger>
-          <AccordionContent className="flex flex-row items-center gap-4">
-            <Switch
-              id="game-reset-collapse"
-              checked={gameSettings.openTasksOnReset}
-              onCheckedChange={openTasksOnResetChange}
-            />
-            <Label htmlFor="game-reset-collapse">Open Tasks On Reset</Label>
-          </AccordionContent>
-        </AccordionItem>
-      </Accordion>
+      {isClient && (
+        <Accordion
+          type="multiple"
+          className="w-full"
+          defaultValue={["app-settings", "game-settings"]}
+        >
+          <AccordionItem value="app-settings">
+            <AccordionTrigger>App Settings</AccordionTrigger>
+            <AccordionContent className="flex flex-row items-center gap-4">
+              <div>Theme</div>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" size="icon">
+                    <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+                    <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+                    <span className="sr-only">Toggle Theme</span>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={() => setTheme("light")}>
+                    Light
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setTheme("dark")}>
+                    Dark
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setTheme("system")}>
+                    System
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem value="game-settings">
+            <AccordionTrigger>Game Settings</AccordionTrigger>
+            <AccordionContent className="flex flex-row items-center gap-4">
+              <Switch
+                id="game-reset-collapse"
+                checked={gameSettings.openTasksOnReset}
+                onCheckedChange={openTasksOnResetChange}
+              />
+              <Label htmlFor="game-reset-collapse">Open Tasks On Reset</Label>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      )}
     </div>
   );
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -17,9 +17,19 @@ import {
 } from "@chron/components/ui/accordion";
 import { Switch } from "@chron/components/ui/switch";
 import { Label } from "@chron/components/ui/label";
+import { useSettings } from "@chron/components/chron/settings-context";
+import { useCallback } from "react";
 
 export default function Settings() {
   const { setTheme } = useTheme();
+  const { gameSettings, setGameSettings } = useSettings();
+
+  const openTasksOnResetChange = useCallback(
+    (value: boolean) => {
+      setGameSettings((prev) => ({ ...prev, openTasksOnReset: value }));
+    },
+    [setGameSettings]
+  );
 
   return (
     <div className="flex flex-col gap-2 px-7">
@@ -57,7 +67,11 @@ export default function Settings() {
         <AccordionItem value="game-settings">
           <AccordionTrigger>Game Settings</AccordionTrigger>
           <AccordionContent className="flex flex-row items-center gap-4">
-            <Switch id="game-reset-collapse" />
+            <Switch
+              id="game-reset-collapse"
+              checked={gameSettings.openTasksOnReset}
+              onCheckedChange={openTasksOnResetChange}
+            />
             <Label htmlFor="game-reset-collapse">Open Tasks On Reset</Label>
           </AccordionContent>
         </AccordionItem>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -9,35 +9,59 @@ import {
 import { Button } from "@chron/components/ui/button";
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@chron/components/ui/accordion";
+import { Switch } from "@chron/components/ui/switch";
+import { Label } from "@chron/components/ui/label";
 
 export default function Settings() {
   const { setTheme } = useTheme();
 
   return (
     <div className="flex flex-col gap-2 px-7">
-      <div className="flex flex-row items-center gap-4">
-        <div>Theme</div>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="icon">
-              <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-              <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-              <span className="sr-only">Toggle Theme</span>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => setTheme("light")}>
-              Light
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => setTheme("dark")}>
-              Dark
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => setTheme("system")}>
-              System
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+      <Accordion
+        type="multiple"
+        className="w-full"
+        defaultValue={["app-settings", "game-settings"]}
+      >
+        <AccordionItem value="app-settings">
+          <AccordionTrigger>App Settings</AccordionTrigger>
+          <AccordionContent className="flex flex-row items-center gap-4">
+            <div>Theme</div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="icon">
+                  <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+                  <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+                  <span className="sr-only">Toggle Theme</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => setTheme("light")}>
+                  Light
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => setTheme("dark")}>
+                  Dark
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => setTheme("system")}>
+                  System
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="game-settings">
+          <AccordionTrigger>Game Settings</AccordionTrigger>
+          <AccordionContent className="flex flex-row items-center gap-4">
+            <Switch id="game-reset-collapse" />
+            <Label htmlFor="game-reset-collapse">Open Tasks On Reset</Label>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     </div>
   );
 }

--- a/components/chron/game.tsx
+++ b/components/chron/game.tsx
@@ -29,6 +29,7 @@ import {
   createTask,
   deleteTask,
   getTasksByGameId,
+  updateGameOpenState,
   updateTaskDone,
   updateTaskOrder,
 } from "@chron/lib/database";
@@ -73,7 +74,7 @@ export default function Game({
         description,
         done: false,
         nextReset: null,
-        closed: false,
+        open: true,
       };
 
       setTasks((prev) => prev.concat([newItem]));
@@ -124,6 +125,11 @@ export default function Game({
     },
     [tasks, nextDaily, nextWeekly, sortTasks]
   );
+
+  const openGame = useCallback((open: boolean) => {
+    setOpen(open);
+    updateGameOpenState(game.id, open).catch(error);
+  }, []);
 
   useEffect(() => {
     getTasksByGameId(game.id)
@@ -176,7 +182,7 @@ export default function Game({
         />
       </CardHeader>
       <CardContent>
-        <Collapsible open={open} onOpenChange={setOpen}>
+        <Collapsible open={open} onOpenChange={openGame}>
           <div className="flex flex-row place-items-center place-content-between">
             <div className="flex flex-row place-items-center">
               <CollapsibleTrigger asChild>

--- a/components/chron/game.tsx
+++ b/components/chron/game.tsx
@@ -73,6 +73,7 @@ export default function Game({
         description,
         done: false,
         nextReset: null,
+        closed: false,
       };
 
       setTasks((prev) => prev.concat([newItem]));

--- a/components/chron/game.tsx
+++ b/components/chron/game.tsx
@@ -74,7 +74,6 @@ export default function Game({
         description,
         done: false,
         nextReset: null,
-        open: true,
       };
 
       setTasks((prev) => prev.concat([newItem]));
@@ -126,10 +125,13 @@ export default function Game({
     [tasks, nextDaily, nextWeekly, sortTasks]
   );
 
-  const openGame = useCallback((open: boolean) => {
-    setOpen(open);
-    updateGameOpenState(game.id, open).catch(error);
-  }, []);
+  const openGame = useCallback(
+    (open: boolean) => {
+      setOpen(open);
+      updateGameOpenState(game.id, open).catch(error);
+    },
+    [game]
+  );
 
   useEffect(() => {
     getTasksByGameId(game.id)

--- a/components/chron/game.tsx
+++ b/components/chron/game.tsx
@@ -34,6 +34,7 @@ import {
   updateTaskOrder,
 } from "@chron/lib/database";
 import { error } from "@tauri-apps/plugin-log";
+import { useSettings } from "@chron/components/chron/settings-context";
 
 export default function Game({
   game,
@@ -49,6 +50,7 @@ export default function Game({
   const [tasks, setTasks] = useState<TaskItem[]>([]);
 
   const { currentTimestamp } = useTimer();
+  const { gameSettings } = useSettings();
 
   const reorderTasks = useCallback((a: TaskItem[]) => {
     return a.map<TaskItem>((item, i) => ({ ...item, order: i }));
@@ -164,6 +166,10 @@ export default function Game({
           .concat(updatedTasks)
           .sort(sortTasks)
       );
+
+      if (gameSettings.openTasksOnReset) {
+        openGame(true);
+      }
 
       Promise.all(
         updatedTasks.map(async (task) =>

--- a/components/chron/game.tsx
+++ b/components/chron/game.tsx
@@ -43,7 +43,7 @@ export default function Game({
   deleteGame: (id: string) => void;
 }) {
   const [loading, setLoading] = useState(true);
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(game.open);
   const [nextDaily, setNextDaily] = useState<Date | null>(null);
   const [nextWeekly, setNextWeekly] = useState<Date | null>(null);
   const [tasks, setTasks] = useState<TaskItem[]>([]);

--- a/components/chron/settings-context.tsx
+++ b/components/chron/settings-context.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import {
+  ComponentProps,
+  createContext,
+  Dispatch,
+  forwardRef,
+  SetStateAction,
+  useContext,
+  useMemo,
+} from "react";
+import { useLocalStorage } from "@chron/components/chron/use-local-storage";
+import { GameSettings } from "@chron/lib/game-settings";
+import { cn } from "@chron/lib/utils";
+
+type SettingsContext = {
+  gameSettings: GameSettings;
+  setGameSettings: Dispatch<SetStateAction<GameSettings>>;
+};
+
+const SettingsContext = createContext<SettingsContext | null>(null);
+
+function useSettings() {
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error("useSettings must be used within a SettingsProvider.");
+  }
+
+  return context;
+}
+
+const SettingsProvider = forwardRef<HTMLDivElement, ComponentProps<"div">>(
+  ({ className, style, children, ...props }, ref) => {
+    const [gameSettings, setGameSettings] = useLocalStorage<GameSettings>(
+      "game-settings",
+      { openTasksOnReset: true }
+    );
+
+    const contextValue = useMemo<SettingsContext>(
+      () => ({ gameSettings, setGameSettings }),
+      [gameSettings, setGameSettings]
+    );
+
+    return (
+      <SettingsContext.Provider value={contextValue}>
+        <div style={style} className={cn(className)} ref={ref} {...props}>
+          {children}
+        </div>
+      </SettingsContext.Provider>
+    );
+  }
+);
+SettingsProvider.displayName = "SettingsProvider";
+
+export { useSettings, SettingsProvider };

--- a/components/chron/sidebar.tsx
+++ b/components/chron/sidebar.tsx
@@ -13,7 +13,7 @@ import { LayoutDashboard, Settings } from "lucide-react";
 export default function ChronSidebar() {
   const items = [
     {
-      title: "Dashboard",
+      title: "Home",
       icon: LayoutDashboard,
       url: "/",
     },

--- a/components/chron/use-local-storage.tsx
+++ b/components/chron/use-local-storage.tsx
@@ -1,4 +1,4 @@
-"use client;";
+"use client";
 
 import { useState, useEffect, Dispatch, SetStateAction } from "react";
 

--- a/components/chron/use-local-storage.tsx
+++ b/components/chron/use-local-storage.tsx
@@ -1,0 +1,24 @@
+"use client;";
+
+import { useState, useEffect, Dispatch, SetStateAction } from "react";
+
+function getStorageValue<T>(key: string, defaultValue: T): T {
+  const item = localStorage.getItem(key);
+  const value = item !== null ? JSON.parse(item) : defaultValue;
+  return value;
+}
+
+export const useLocalStorage = <T,>(
+  key: string,
+  defaultValue: T
+): [T, Dispatch<SetStateAction<T>>] => {
+  const [value, setValue] = useState(() => {
+    return getStorageValue(key, defaultValue);
+  });
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(value));
+  }, [key, value]);
+
+  return [value, setValue];
+};

--- a/components/chron/use-local-storage.tsx
+++ b/components/chron/use-local-storage.tsx
@@ -3,9 +3,13 @@
 import { useState, useEffect, Dispatch, SetStateAction } from "react";
 
 function getStorageValue<T>(key: string, defaultValue: T): T {
-  const item = localStorage.getItem(key);
-  const value = item !== null ? JSON.parse(item) : defaultValue;
-  return value;
+  if (typeof window !== "undefined") {
+    const item = localStorage.getItem(key);
+    const value = item !== null ? JSON.parse(item) : defaultValue;
+    return value;
+  }
+
+  return defaultValue;
 }
 
 export const useLocalStorage = <T,>(

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDown } from "lucide-react";
+
+import { cn } from "@chron/lib/utils";
+
+const Accordion = AccordionPrimitive.Root;
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn("border-b", className)}
+    {...props}
+  />
+));
+AccordionItem.displayName = "AccordionItem";
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline text-left [&[data-state=open]>svg]:rotate-180",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200" />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+));
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    {...props}
+  >
+    <div className={cn("pb-4 pt-0", className)}>{children}</div>
+  </AccordionPrimitive.Content>
+));
+AccordionContent.displayName = AccordionPrimitive.Content.displayName;
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+
+import { cn } from "@chron/lib/utils";
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -31,7 +31,7 @@ export async function createGame(game: GameItem): Promise<void> {
   const db = await loadDb();
 
   await db.execute(
-    "INSERT INTO `games` (`id`, `title`, `dailyHour`, `dailyMinute`, `weeklyDay`, `order`, `open`) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    "INSERT INTO `games` (`id`, `title`, `dailyHour`, `dailyMinute`, `weeklyDay`, `order`) VALUES ($1, $2, $3, $4, $5, $6)",
     [
       game.id,
       game.title,
@@ -39,7 +39,6 @@ export async function createGame(game: GameItem): Promise<void> {
       game.dailyMinute,
       game.weeklyDay,
       game.order,
-      game.open,
     ]
   );
 }

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -24,7 +24,7 @@ export async function createGame(game: GameItem): Promise<void> {
   const db = await loadDb();
 
   await db.execute(
-    "INSERT INTO `games` (`id`, `title`, `dailyHour`, `dailyMinute`, `weeklyDay`, `order`, `closed`) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    "INSERT INTO `games` (`id`, `title`, `dailyHour`, `dailyMinute`, `weeklyDay`, `order`, `open`) VALUES ($1, $2, $3, $4, $5, $6, $7)",
     [
       game.id,
       game.title,
@@ -32,7 +32,7 @@ export async function createGame(game: GameItem): Promise<void> {
       game.dailyMinute,
       game.weeklyDay,
       game.order,
-      game.closed,
+      game.open,
     ]
   );
 }
@@ -55,14 +55,14 @@ export async function updateGameOrder(
   ]);
 }
 
-export async function updateGameClosedState(
+export async function updateGameOpenState(
   gameId: string,
-  closed: boolean
+  open: boolean
 ): Promise<void> {
   const db = await loadDb();
 
-  await db.execute("UPDATE `games` SET `closed` = $1 WHERE `id` = $2", [
-    closed ? 1 : 0,
+  await db.execute("UPDATE `games` SET `open` = $1 WHERE `id` = $2", [
+    open ? 1 : 0,
     gameId,
   ]);
 }
@@ -74,7 +74,7 @@ export async function createTask(
   const db = await loadDb();
 
   await db.execute(
-    "INSERT INTO `tasks` (`id`, `gameId`, `title`, `type`, `description`, `order`, `closed`) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    "INSERT INTO `tasks` (`id`, `gameId`, `title`, `type`, `description`, `order`, `open`) VALUES ($1, $2, $3, $4, $5, $6, $7)",
     [
       task.id,
       gameId,
@@ -82,7 +82,7 @@ export async function createTask(
       task.type,
       task.description,
       task.order,
-      task.closed,
+      task.open,
     ]
   );
 }
@@ -118,14 +118,14 @@ export async function updateTaskDone(
   );
 }
 
-export async function updateTaskClosedState(
+export async function updateTaskOpenState(
   taskId: string,
-  closed: boolean
+  open: boolean
 ): Promise<void> {
   const db = await loadDb();
 
-  await db.execute("UPDATE `tasks` SET `closed` = $1 WHERE `id` = $2", [
-    closed ? 1 : 0,
+  await db.execute("UPDATE `tasks` SET `open` = $1 WHERE `id` = $2", [
+    open ? 1 : 0,
     taskId,
   ]);
 }

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -9,15 +9,22 @@ async function loadDb(): Promise<Database> {
 export async function getAllGames(): Promise<GameItem[]> {
   const db = await loadDb();
 
-  return db.select<GameItem[]>("SELECT * FROM `games`");
+  const games = await db.select<GameItem[]>("SELECT * FROM `games`");
+
+  // game.open is expected to be a boolean, but stored in db as int
+  return games.map((game) => ({ ...game, open: !!game.open }));
 }
 
 export async function getTasksByGameId(gameId: string): Promise<TaskItem[]> {
   const db = await loadDb();
 
-  return db.select<TaskItem[]>("SELECT * FROM `tasks` WHERE `gameId` = $1", [
-    gameId,
-  ]);
+  const tasks = await db.select<TaskItem[]>(
+    "SELECT * FROM `tasks` WHERE `gameId` = $1",
+    [gameId]
+  );
+
+  // task.done is expected to be a boolean, but stored in db as int
+  return tasks.map((task) => ({ ...task, done: !!task.done }));
 }
 
 export async function createGame(game: GameItem): Promise<void> {

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -55,6 +55,18 @@ export async function updateGameOrder(
   ]);
 }
 
+export async function updateGameClosedState(
+  gameId: string,
+  closed: boolean
+): Promise<void> {
+  const db = await loadDb();
+
+  await db.execute("UPDATE `games` SET `closed` = $1 WHERE `id` = $2", [
+    closed ? 1 : 0,
+    gameId,
+  ]);
+}
+
 export async function createTask(
   task: Omit<TaskItem, "done" | "nextReset">,
   gameId: string
@@ -104,4 +116,16 @@ export async function updateTaskDone(
     "UPDATE `tasks` SET `done` = $1, `nextReset` = $2 WHERE `id` = $3",
     [done ? 1 : 0, nextReset?.getTime(), taskId]
   );
+}
+
+export async function updateTaskClosedState(
+  taskId: string,
+  closed: boolean
+): Promise<void> {
+  const db = await loadDb();
+
+  await db.execute("UPDATE `tasks` SET `closed` = $1 WHERE `id` = $2", [
+    closed ? 1 : 0,
+    taskId,
+  ]);
 }

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -74,16 +74,8 @@ export async function createTask(
   const db = await loadDb();
 
   await db.execute(
-    "INSERT INTO `tasks` (`id`, `gameId`, `title`, `type`, `description`, `order`, `open`) VALUES ($1, $2, $3, $4, $5, $6, $7)",
-    [
-      task.id,
-      gameId,
-      task.title,
-      task.type,
-      task.description,
-      task.order,
-      task.open,
-    ]
+    "INSERT INTO `tasks` (`id`, `gameId`, `title`, `type`, `description`, `order`) VALUES ($1, $2, $3, $4, $5, $6)",
+    [task.id, gameId, task.title, task.type, task.description, task.order]
   );
 }
 
@@ -116,16 +108,4 @@ export async function updateTaskDone(
     "UPDATE `tasks` SET `done` = $1, `nextReset` = $2 WHERE `id` = $3",
     [done ? 1 : 0, nextReset?.getTime(), taskId]
   );
-}
-
-export async function updateTaskOpenState(
-  taskId: string,
-  open: boolean
-): Promise<void> {
-  const db = await loadDb();
-
-  await db.execute("UPDATE `tasks` SET `open` = $1 WHERE `id` = $2", [
-    open ? 1 : 0,
-    taskId,
-  ]);
 }

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -24,7 +24,7 @@ export async function createGame(game: GameItem): Promise<void> {
   const db = await loadDb();
 
   await db.execute(
-    "INSERT INTO `games` (`id`, `title`, `dailyHour`, `dailyMinute`, `weeklyDay`, `order`) VALUES ($1, $2, $3, $4, $5, $6)",
+    "INSERT INTO `games` (`id`, `title`, `dailyHour`, `dailyMinute`, `weeklyDay`, `order`, `closed`) VALUES ($1, $2, $3, $4, $5, $6, $7)",
     [
       game.id,
       game.title,
@@ -32,6 +32,7 @@ export async function createGame(game: GameItem): Promise<void> {
       game.dailyMinute,
       game.weeklyDay,
       game.order,
+      game.closed,
     ]
   );
 }
@@ -61,8 +62,16 @@ export async function createTask(
   const db = await loadDb();
 
   await db.execute(
-    "INSERT INTO `tasks` (`id`, `gameId`, `title`, `type`, `description`, `order`) VALUES ($1, $2, $3, $4, $5, $6)",
-    [task.id, gameId, task.title, task.type, task.description, task.order]
+    "INSERT INTO `tasks` (`id`, `gameId`, `title`, `type`, `description`, `order`, `closed`) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    [
+      task.id,
+      gameId,
+      task.title,
+      task.type,
+      task.description,
+      task.order,
+      task.closed,
+    ]
   );
 }
 

--- a/lib/game-settings.ts
+++ b/lib/game-settings.ts
@@ -1,0 +1,3 @@
+export interface GameSettings {
+  openTasksOnReset: boolean;
+}

--- a/lib/game.ts
+++ b/lib/game.ts
@@ -5,4 +5,5 @@ export interface GameItem {
   dailyHour: number;
   dailyMinute: number;
   weeklyDay: number;
+  closed: boolean;
 }

--- a/lib/game.ts
+++ b/lib/game.ts
@@ -5,5 +5,5 @@ export interface GameItem {
   dailyHour: number;
   dailyMinute: number;
   weeklyDay: number;
-  closed: boolean;
+  open: boolean;
 }

--- a/lib/task.ts
+++ b/lib/task.ts
@@ -6,6 +6,7 @@ export interface TaskItem {
   description: string;
   done: boolean;
   nextReset: Date | null;
+  closed: boolean;
 }
 
 export type TaskType = "daily" | "weekly";

--- a/lib/task.ts
+++ b/lib/task.ts
@@ -6,7 +6,7 @@ export interface TaskItem {
   description: string;
   done: boolean;
   nextReset: Date | null;
-  closed: boolean;
+  open: boolean;
 }
 
 export type TaskType = "daily" | "weekly";

--- a/lib/task.ts
+++ b/lib/task.ts
@@ -6,7 +6,6 @@ export interface TaskItem {
   description: string;
   done: boolean;
   nextReset: Date | null;
-  open: boolean;
 }
 
 export type TaskType = "daily" | "weekly";

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tauri-apps/plugin-log": "^2.8.0",
         "@tauri-apps/plugin-shell": "^2.3.4",
@@ -2072,6 +2073,35 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.3",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -1320,6 +1321,37 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tauri-apps/plugin-log": "^2.8.0",
     "@tauri-apps/plugin-shell": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,9 +31,8 @@ pub fn run() {
     },
     Migration {
         version: 2,
-        description: "Add open state to games and tasks",
-        sql: "ALTER TABLE games ADD open INTEGER DEFAULT (1) NOT NULL;
-              ALTER TABLE tasks ADD open INTEGER DEFAULT (1) NOT NULL;",
+        description: "Add open state to games",
+        sql: "ALTER TABLE games ADD open INTEGER DEFAULT (1) NOT NULL;",
         kind: MigrationKind::Up
     }
     ];

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,9 +31,9 @@ pub fn run() {
     },
     Migration {
         version: 2,
-        description: "Add closed state to games and tasks",
-        sql: "ALTER TABLE games ADD closed INTEGER DEFAULT (0) NOT NULL;
-              ALTER TABLE tasks ADD closed INTEGER DEFAULT (0) NOT NULL;",
+        description: "Add open state to games and tasks",
+        sql: "ALTER TABLE games ADD open INTEGER DEFAULT (1) NOT NULL;
+              ALTER TABLE tasks ADD open INTEGER DEFAULT (1) NOT NULL;",
         kind: MigrationKind::Up
     }
     ];

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,7 +28,15 @@ pub fn run() {
                   CONSTRAINT tasks_games_FK FOREIGN KEY (gameId) REFERENCES games(id) ON DELETE CASCADE
               );",
         kind: MigrationKind::Up,
-    }];
+    },
+    Migration {
+        version: 2,
+        description: "Add closed state to games and tasks",
+        sql: "ALTER TABLE games ADD closed INTEGER DEFAULT (0) NOT NULL;
+              ALTER TABLE tasks ADD closed INTEGER DEFAULT (0) NOT NULL;",
+        kind: MigrationKind::Up
+    }
+    ];
 
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {


### PR DESCRIPTION
* Collapsing a game's task list is persisted through application launches
* The settings page has been revamped to include sections
* A new setting for games has been added to the settings page: "Open Tasks On Reset"
  * When enabled, if a game's daily or weekly reset has passed and there were tasks that were reset, the game's task list will re-open
  * When disabled, instead the task list will remain collapsed
  * Defaults to enabled