### PR TITLE
ci: Enforce Conventional Commits

### DIFF
--- a/.github/workflows/conventional-commit-title.yml
+++ b/.github/workflows/conventional-commit-title.yml
@@ -1,0 +1,49 @@
+name: "Conventional Commit Title"
+
+# Every PR is squash-merged into `main`, and GitHub's repo setting
+# "Default commit message for squash merging" is set to "Pull request title",
+# so the PR title becomes the commit subject on `main` verbatim.
+# Validating the PR title here is what enforces Conventional Commits on `main`.
+#
+# See CONTRIBUTING.md ("Commit Messages") for the policy this check implements.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          # Disallow subjects that start with an uppercase letter, per the
+          # Conventional Commits convention (lowercase, imperative mood).
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.

--- a/.github/workflows/conventional-commit-title.yml
+++ b/.github/workflows/conventional-commit-title.yml
@@ -1,12 +1,5 @@
 name: "Conventional Commit Title"
 
-# Every PR is squash-merged into `main`, and GitHub's repo setting
-# "Default commit message for squash merging" is set to "Pull request title",
-# so the PR title becomes the commit subject on `main` verbatim.
-# Validating the PR title here is what enforces Conventional Commits on `main`.
-#
-# See CONTRIBUTING.md ("Commit Messages") for the policy this check implements.
-
 on:
   pull_request:
     types:
@@ -15,11 +8,6 @@ on:
       - reopened
       - synchronize
 
-# `pull_request` (not `pull_request_target`) runs the workflow in a sandboxed
-# fork context with a read-only GITHUB_TOKEN and no access to repository
-# secrets, which is all this check needs. This shrinks the blast radius if a
-# future edit ever adds an `actions/checkout` step of the PR head, which
-# would be a credential-exfiltration footgun under `pull_request_target`.
 permissions:
   contents: read
   pull-requests: read
@@ -29,12 +17,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      # Third-party action pinned to a full commit SHA rather than a moving
-      # tag (`@v6`) to defend against the tj-actions class of supply-chain
-      # attack, where a compromised maintainer account can force-push the tag
-      # to point at malicious code. Bump the pin (and the trailing comment)
-      # when upgrading; Dependabot's `github-actions` ecosystem can do this
-      # automatically.
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -52,8 +34,6 @@ jobs:
             chore
             revert
           requireScope: false
-          # Disallow subjects that start with an uppercase letter, per the
-          # Conventional Commits convention (lowercase, imperative mood).
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"

--- a/.github/workflows/conventional-commit-title.yml
+++ b/.github/workflows/conventional-commit-title.yml
@@ -8,14 +8,20 @@ name: "Conventional Commit Title"
 # See CONTRIBUTING.md ("Commit Messages") for the policy this check implements.
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
       - reopened
       - synchronize
 
+# `pull_request` (not `pull_request_target`) runs the workflow in a sandboxed
+# fork context with a read-only GITHUB_TOKEN and no access to repository
+# secrets, which is all this check needs. This shrinks the blast radius if a
+# future edit ever adds an `actions/checkout` step of the PR head, which
+# would be a credential-exfiltration footgun under `pull_request_target`.
 permissions:
+  contents: read
   pull-requests: read
 
 jobs:
@@ -23,7 +29,13 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      # Third-party action pinned to a full commit SHA rather than a moving
+      # tag (`@v6`) to defend against the tj-actions class of supply-chain
+      # attack, where a compromised maintainer account can force-push the tag
+      # to point at malicious code. Bump the pin (and the trailing comment)
+      # when upgrading; Dependabot's `github-actions` ecosystem can do this
+      # automatically.
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,9 +147,25 @@ Updating, improving and correcting the documentation
 
 ## Styleguides
 ### Commit Messages
-<!-- TODO
 
--->
+Every commit that lands on `main` must follow the [Conventional Commits](https://www.conventionalcommits.org/) spec. Because pull requests are squash-merged and GitHub is configured to use the PR title as the squash commit message, **the rule applies to your PR title** — individual commits on your working branch can be named however you like; they get thrown away by the squash.
+
+The PR title must match:
+
+```
+<type>(<optional scope>): <subject>
+```
+
+Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`. The subject should be lowercase and in the imperative mood.
+
+Examples pulled from recent history:
+
+- `feat: persistent collapsible task lists`
+- `chore(deps): bump rsa from 0.9.7 to 0.9.10`
+- `chore: bump version to 0.0.4`
+
+The `Conventional Commit Title` GitHub Actions check runs on every PR and will fail if the title doesn't match. Editing the PR title re-triggers the check, so you can fix it in place without pushing anything.
+
 
 ## Join The Project Team
 <!-- TODO -->


### PR DESCRIPTION
Added a workflow to enforce conventional commits in PR titles 