### PR TITLE
ci: harden workflows against action supply-chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,9 @@ on:
 # This workflow uses different actions to create and publish the release.
 # `tauri-action` will only build and upload the app bundles to the specified release.
 
+permissions:
+  contents: read
+
 jobs:
   create-release:
     permissions:
@@ -17,19 +20,19 @@ jobs:
       release_id: ${{ steps.create-release.outputs.result }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24.x
 
       - name: get version
-        run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+        run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> "$GITHUB_ENV"
 
       - name: create release
         id: create-release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const { data } = await github.rest.repos.getReleaseByTag({
@@ -58,15 +61,15 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24.x
 
       - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
@@ -80,7 +83,7 @@ jobs:
       - name: install frontend dependencies
         run: npm install # change this to npm, pnpm or bun depending on which one you use.
 
-      - uses: tauri-apps/tauri-action@v0
+      - uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -4,6 +4,9 @@ on: [pull_request]
 
 # This workflow will build your tauri app without uploading it anywhere.
 
+permissions:
+  contents: read
+
 jobs:
   test-tauri:
     strategy:
@@ -21,15 +24,15 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24.x
 
       - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
@@ -45,7 +48,7 @@ jobs:
         run: npm install # change this to npm, pnpm or bun depending on which one you use.
 
       # If tagName and releaseId are omitted tauri-action will only build the app and won't try to upload any assets.
-      - uses: tauri-apps/tauri-action@v0
+      - uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## What

Hardens the three GitHub Actions workflows in this repo against the class of supply-chain attacks that hit **tj-actions/changed-files (CVE-2025-30066)** and **reviewdog/action-setup** in March 2025.

Three changes on top of `main`:

1. **SHA-pin every third-party action** (with the human-readable version kept in a trailing `# vX.Y.Z` comment). No version bumps — each SHA is what the previously floating tag resolved to at the time of this commit.
2. **Set workflow-level `permissions: contents: read`** on `test-build.yml` and `publish-release.yml` so a future compromise starts with a read-only `GITHUB_TOKEN`. Per-job `contents: write` on the two release jobs stays — they legitimately need it.
3. **Add `.github/dependabot.yml`** for the `github-actions` ecosystem, grouped so bumps land in one PR/week. Without this, pinned SHAs quietly rot.

Also folded in one unrelated shellcheck fix (`>> "$GITHUB_ENV"` quoting) that `actionlint` was surfacing on a line touched near the pinning changes.

## Why

The March 2025 attacks all worked the same way: attacker steals a PAT from an action maintainer, force-pushes floating version tags (`v1`, `v0`, `stable`) to point at a malicious commit, and every downstream workflow pinned by tag runs the malicious code on its next run — on public repos, secrets get dumped to logs. Pinning by full commit SHA is the mitigation GitHub Security Lab, OpenSSF Scorecard, and SLSA all agree on. Dependabot keeps the pins from drifting.

## Actions pinned

| Action | SHA | Version comment |
|---|---|---|
| `actions/checkout` | `11d5960a326750d5838078e36cf38b85af677262` | `v4` |
| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | `v4` |
| `actions/github-script` | `f28e40c7f34bde8b3046d885e986cb6290c5673b` | `v7` |
| `dtolnay/rust-toolchain` | `4360b52568e2003a75bf9bc1d59f33a8e3fc893c` | `stable` (branch HEAD at pin time) |
| `tauri-apps/tauri-action` | `84b9d35b5fc46c1e45415bdb6144030364f7ebc5` | `v0.6.2` (what `@v0` resolved to) |

`conventional-commit-title.yml` already SHA-pinned its one third-party action, so it's untouched.

## Verification

- `git grep -nE '@(v[0-9]+\|main\|master\|stable\|latest)\s*$' .github/workflows/` → zero live matches.
- `actionlint` (via `rhysd/actionlint:latest` in docker) → clean.
- Once this PR runs, `test-build.yml` on all four matrix legs will exercise the SHA-pinned actions end-to-end.
- `publish-release.yml` won't run until the next real release is cut.

## Reviewer notes

- The `dtolnay/rust-toolchain@stable` action is designed to be branch-ref'd. SHA-pinning locks the *action code* itself; the installed Rust toolchain still floats to the latest stable release. That's the intended behavior.
- Dependabot's grouped-updates config bundles all Actions bumps into a single weekly PR to keep review overhead low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)