### PR TITLE
docs: add CLAUDE.md and AGENTS.md for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+**Read [`CLAUDE.md`](./CLAUDE.md) before you change any file in this repository.**
+
+`CLAUDE.md` is the authoritative instruction file for every coding agent that
+works here, whatever tool you run under. It applies to you. This file exists
+only so that tools which look for `AGENTS.md` are pointed at it.
+
+## This file holds no rules of its own
+
+That is deliberate. Two files describing the same conventions drift apart, and
+an agent then follows whichever copy it happened to open — usually the stale
+one. So the rules live in exactly one place.
+
+If you add or change a convention, edit `CLAUDE.md`. Do not copy a rule into
+this file, and do not add a summary of `CLAUDE.md` here. A short pointer that
+stays correct is worth more than a summary that rots.
+
+## Do not skip it because the repo looks small
+
+chron is a small codebase, so the instructions are easy to read in full and the
+temptation to skim is high. Resist it. `CLAUDE.md` documents several behaviors
+that are wrong to guess at, including:
+
+- How SQLite values come back typed, and where the TypeScript types do not
+  match what is actually in memory.
+- How the daily and weekly reset times are computed, and which stated
+  conventions in the code comments are incorrect.
+- Which generated and stale config files must not be trusted or hand-edited.
+- The required style for code comments and for pull request titles.
+
+The list above is a table of contents, not a summary. Each item is a real trap
+that costs a debugging session if you assume the obvious behavior instead.
+
+## Related files
+
+- [`CLAUDE.md`](./CLAUDE.md) — agent instructions. Authoritative.
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — human contribution process, and the
+  authoritative description of the pull request title rules.
+- [`README.md`](./README.md) — what the product is, for end users.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,61 +9,161 @@ chron is a Tauri 2 desktop app for tracking recurring reset-based tasks in video
 ## Commands
 
 ```bash
-npm install          # install JS deps
-npm run dev           # vite dev server only (no Tauri window) — for pure frontend work
-npm run tauri dev     # full app: spawns vite dev server + opens the Tauri webview window
-npm run build          # tsc --noEmit type-check, then vite build (frontend only, outputs to dist/)
-npm run tauri build    # full desktop build (invokes the frontend build, then bundles a native binary)
+npm install             # install JS deps
+npm run dev             # vite dev server only (no Tauri window) — for pure frontend work
+npm run tauri dev       # full app: spawns vite dev server + opens the Tauri webview window
+npm run build           # tsr generate → tsc --noEmit → vite build (frontend only, outputs to dist/)
+npm run tauri build     # full desktop build (invokes the frontend build, then bundles a native binary)
+npm run preview         # serve a previously built dist/ (plain browser, no Tauri APIs — most of the app will fail)
 npm run lint            # eslint .
-npm run ui add <name>   # add/update a shadcn/ui component (npx shadcn@latest add ...)
+npm run ui add <name>   # add a shadcn/ui component (npx shadcn@latest add ...) — see the caveat below
 ```
 
-There is no test suite in this repo (no `test` script, no test runner configured) — don't assume Vitest/Jest exists.
+`package.json` pins `engines` to Node `^24.12.0` and npm `^11.7.0`. If a build fails in a way that makes no sense, check the Node version first.
+
+`npm run build` runs `tsr generate` before `tsc --noEmit` on purpose: `src/routeTree.gen.ts` is gitignored, so a clean checkout has no route tree and the type-check would fail on the missing import. Don't reorder those steps.
 
 Rust side (`src-tauri/`) can be checked directly with `cargo check` / `cargo build` from that directory if you're only touching Rust.
+
+### There is no test suite
+
+No `test` script, no test runner, no test files — don't assume Vitest/Jest exists and don't invent an `npm test` invocation. Until a runner is added, "verified" means one of:
+
+- `npm run build` for type and compile errors, and `npm run lint`.
+- `npm run tauri dev` and exercising the actual behavior in the app window, for anything touching the database, reset timers, or UI state.
+
+Say which one you did. Type-checking a change to reset logic is not evidence the reset logic is right.
+
+`lib/timer.ts` and `lib/database.ts` are the two places where a test suite would pay for itself most, if you are ever asked where to start.
 
 ## Architecture
 
 ### Frontend/backend split
 
-- `src/`, `components/`, `lib/`, `hooks/` — the React app, bundled by Vite.
+- `src/`, `components/`, `lib/`, `hooks/` — the React app, bundled by Vite. Note that only `src/` holds routes and entrypoints; `components/`, `lib/`, and `hooks/` sit at the repo root, not under `src/`.
 - `src-tauri/` — the Rust shell. `src-tauri/src/lib.rs` is where the Tauri `Builder` is configured: plugins (`sql`, `shell`, `log`, `single-instance`) and the SQLite migration list live here. There is essentially no other Rust logic — all business logic lives in TypeScript.
 - The two are glued together by `src-tauri/tauri.conf.json` (`beforeDevCommand`/`beforeBuildCommand` run the npm scripts above) and by `@tauri-apps/plugin-*` JS APIs called from `lib/`.
 
 ### Data layer
 
-- **Schema/migrations**: defined inline in `src-tauri/src/lib.rs` as a `Vec<Migration>` passed to `tauri_plugin_sql`. To change the schema, add a new migration with the next version number — don't edit an existing migration once it has shipped.
+- **Schema/migrations**: defined inline in `src-tauri/src/lib.rs` as a `Vec<Migration>` passed to `tauri_plugin_sql`. To change the schema, add a new migration with the next version number — don't edit an existing migration once it has shipped, because existing installs have already run it and will never re-run it.
 - **Queries**: all SQL lives in `lib/database.ts`, which opens the db via `Database.load("sqlite:chron.db")` per call. There are two tables, `games` and `tasks` (one-to-many via `gameId`, `ON DELETE CASCADE`).
-- SQLite has no boolean type, so `games.open` and `tasks.done` are stored as `0`/`1` integers. Every read path in `database.ts` manually coerces these back to `boolean` (`!!game.open`) — remember to do the same for any new boolean column.
-- Domain types (`GameItem` in `lib/game.ts`, `TaskItem`/`TaskType` in `lib/task.ts`) are hand-maintained TS interfaces that mirror the SQL columns; they are not generated from the migrations. Zod validation schemas for the create/edit forms (`lib/zod.ts`, using zod v4's `error` callback API) are a **separate, manually-kept-in-sync** definition of roughly the same shape — update both when a field changes.
+- All queries use bound parameters (`$1`, `$2`, ...). Keep it that way — never build a statement by string concatenation, even for a value that looks safe.
+
+#### SQLite has no rich types, and the TS types lie about it
+
+This is the single biggest source of surprise in this codebase. `db.select<T[]>(...)` is an unchecked cast: whatever SQLite returns is asserted to be `T`, with no validation and no conversion. So a declared type is a claim, not a guarantee.
+
+Current state of that gap:
+
+- `games.open` and `tasks.done` are stored as `0`/`1` integers. `getAllGames` and `getTasksByGameId` manually coerce them back with `!!` — **do the same for any new boolean column**, in every read path, or the value will be a truthy `0`/`1` number.
+- `tasks.nextReset` is stored as an integer (written as `nextReset?.getTime()`) but declared `Date | null` on `TaskItem`. **Nothing converts it back.** At runtime a task loaded from the database has a `number` there. It currently works only because `date-fns` `isAfter` also accepts a timestamp. Don't call a `Date` method on it, and don't trust the declared type.
+- `TaskItem` has no `gameId` field even though the column exists and `SELECT *` returns it.
+
+If you touch this area, prefer narrowing the gap (convert at the boundary in `database.ts`) over adding another consumer that works around it.
+
+#### Duplicated shape definitions
+
+Three separate hand-maintained definitions describe roughly the same data, and none is generated from another:
+
+| Definition | Lives in | Covers |
+| --- | --- | --- |
+| SQL columns | `src-tauri/src/lib.rs` migrations | Storage |
+| TS interfaces | `lib/game.ts` (`GameItem`), `lib/task.ts` (`TaskItem`, `TaskType`) | Runtime shape |
+| Zod schemas | `lib/zod.ts` (`gameSchema`, `taskSchema`, `TaskType`) | Create/edit form validation |
+
+Adding or changing a field means editing all three. `TaskType` in particular exists twice — as a TS union in `lib/task.ts` and as a `z.enum` in `lib/zod.ts`.
+
+`lib/zod.ts` uses zod v4's `error` callback API (`z.string({ error: (issue) => ... })`), not the older `required_error`/`invalid_type_error` options. Match the surrounding style.
 
 ### Reset-time logic
 
-`lib/timer.ts` computes daily/weekly reset windows. Key conventions:
-- `dailyTime` is always a string in `HH:mm:ss.sssZ` form (a JS Date time-string suffix), combined with today's date and parsed as UTC.
-- `weeklyDay` is 0–6 (JS `Date.getDay()`/`date-fns setDay` convention, i.e. 0 = Sunday).
-- Functions are pure and take the reset config in; they don't read from the DB or React state themselves.
+`lib/timer.ts` computes daily/weekly reset windows. Read the whole file before changing any of it — it is small, and the conventions are easy to get subtly wrong.
+
+- `dailyTime` is a string in `HH:mm:ss.sssZ` form, built by `formatDailyTime(hours, minutes)` from the `dailyHour`/`dailyMinute` integer columns. Note that the database stores hour and minute, not the string; the string only exists in memory.
+- **The `Z` suffix does not mean the reset is UTC.** `getTodayTimes` parses `${todayDate}T${dailyTime}` as UTC, then immediately reads it back with local-time `getHours()`/`getMinutes()` and applies those to today via `set()`. The net effect is that the configured time is shifted by the machine's UTC offset. Treat this as the current behavior, not as an intended spec — if you are asked to "fix timezone handling", this is the code that matters, and changing it will move every existing user's reset time.
+- `weeklyDay` is 0–6 in the JS `Date.getDay()` / `date-fns` `setDay` convention, i.e. **0 = Sunday**. Several JSDoc comments in the file call it "ISO date of the week", which is wrong — ISO weekdays are 1–7 starting Monday. Trust the code and this note, not those comments.
+- **These functions are not pure.** Every one of them calls `new Date()` internally through `getTodayTimes`, so results depend on the wall clock and cannot be tested without faking time. They do not read the database or React state.
 
 ### React app structure
 
-- Routing is file-based via `@tanstack/react-router`'s Vite plugin: files under `src/routes/` are scanned and compiled into `src/routeTree.gen.ts`, which is **generated and gitignored** — never hand-edit it, and don't be surprised if it's missing before the first dev/build run. `src/routes/__root.tsx` defines the app shell (theme, sidebar, providers); `src/routes/index.tsx` is the dashboard; new pages are added by dropping a file in `src/routes/`.
-- The router uses **hash history** (`createHashHistory`), specifically so deep links survive under Tauri's custom asset protocol without extra Rust-side URL rewriting — don't switch this to browser history without checking that still holds.
-- Two app-level React contexts wrap everything in `__root.tsx`:
-  - `TimerProvider` (`components/chron/timer-context.tsx`) — ticks a shared `currentTimestamp` every second; use `useTimer()` instead of each component running its own interval.
-  - `SettingsProvider` (`components/chron/settings-context.tsx`) — wraps `GameSettings` (`lib/game-settings.ts`) in `localStorage` via `use-local-storage.tsx`.
-- `components/ui/` is shadcn/ui (new-york style, generated — see `components.json`); treat it as vendored and prefer adding new primitives via `npm run ui add` rather than hand-writing. `components/chron/` is app-specific composition on top of it (game cards, task lists, dialogs, sidebar).
+- Routing is file-based via `@tanstack/react-router`'s Vite plugin: files under `src/routes/` are scanned and compiled into `src/routeTree.gen.ts`, which is **generated and gitignored** — never hand-edit it, and don't be surprised if it's missing before the first dev/build run (`npx tsr generate` regenerates it on demand). Current routes: `src/routes/__root.tsx` (app shell), `src/routes/index.tsx` (dashboard), `src/routes/settings.tsx`. New pages are added by dropping a file in `src/routes/`.
+- The router uses **hash history** (`createHashHistory` in `src/router.tsx`), specifically so deep links survive under Tauri's custom asset protocol without extra Rust-side URL rewriting — don't switch this to browser history without checking that still holds.
+- Three providers wrap everything in `__root.tsx`, outermost first: `ThemeProvider` (`next-themes`, class strategy, defaults to dark), then `SettingsProvider`, then `TimerProvider`, then `SidebarProvider`.
+  - `TimerProvider` (`components/chron/timer-context.tsx`) ticks a shared `currentTimestamp` every second; use `useTimer()` instead of each component running its own interval.
+  - `SettingsProvider` (`components/chron/settings-context.tsx`) wraps `GameSettings` (`lib/game-settings.ts`) in `localStorage` via `components/chron/use-local-storage.tsx`.
+- `components/ui/` is shadcn/ui (new-york style, generated — see `components.json`); treat it as vendored. `components/chron/` is app-specific composition on top of it (game cards, task lists, dialogs, sidebar).
+
+#### `components.json` is stale, so `npm run ui add` needs cleanup
+
+It still carries Next.js-era settings from before the Vite refactor and nobody has corrected them:
+
+- `"rsc": true` — this repo has no React Server Components. Generated files may arrive with a `"use client"` directive that does nothing here.
+- `"tailwind.config": "tailwind.config.ts"` — that file does not exist (Tailwind v4 is configured through `@tailwindcss/postcss`, no JS config file).
+- `"tailwind.css": "app/globals.css"` — the real stylesheet is `src/styles/globals.css`.
+
+Still prefer `npm run ui add` over hand-writing a primitive, but **read the generated file before committing it** and strip anything the paths above dragged in. Fixing `components.json` itself is a welcome small PR.
 
 ### Path aliases
 
-`@chron/*` resolves to the repo root (configured in both `tsconfig.json` paths and the Vite `resolve.alias`) — e.g. `@chron/lib/database`, `@chron/components/ui/button`. Use this instead of relative `../../..` imports.
+`@chron/*` resolves to the repo root, configured in **two** places that must stay in sync: `paths` in `tsconfig.json` (for the type-checker) and `resolve.alias` in `vite.config.ts` (for the bundler). Editing only one produces a build that type-checks and fails at runtime, or vice versa. Use `@chron/lib/database`, `@chron/components/ui/button`, etc. instead of relative `../../..` imports.
 
 ### Tauri capabilities
 
-Any new Tauri plugin/API surface used from the frontend needs a matching permission added to `src-tauri/capabilities/default.json`, or the call will fail at runtime with a permission error even though it type-checks.
+Any new Tauri plugin/API surface used from the frontend needs a matching permission added to `src-tauri/capabilities/default.json`, or the call will fail at runtime with a permission error even though it type-checks. The current list is deliberately narrow (`shell:allow-open`, the `sql:*` set, `log:*`) — adding a permission widens what the webview can do, so add the specific one you need rather than a broad default.
+
+## Code comments
+
+Default to no comment. Well-named functions and variables already say what the code does; a comment that restates them is noise that later goes stale. Add one only for a hidden constraint, a non-obvious workaround, or a reason a reader would find surprising — the kind of thing that explains *why*, not *what*.
+
+A comment that overstates what the code guarantees is worse than no comment. If you find one, correcting it may be the whole fix. There are live examples in `lib/timer.ts` (see the reset-time section above).
+
+### Write comments in Simplified Technical English (ASD-STE100)
+
+Comments in this repo follow ASD-STE100 Simplified Technical English. The point is that a comment should be readable once, quickly, with no ambiguity — so apply the rules that carry that, not the full aerospace specification:
+
+- **One idea per sentence.** Keep sentences under about 20 words.
+- **Active voice, with a subject.** "`getTodayTimes` reads the local clock", not "the local clock is read".
+- **One word, one meaning.** Pick a term and reuse it exactly. Don't alternate between "task", "item", and "entry" for the same thing.
+- **Use the simple present tense** for what the code does, and the simple past only for history ("this replaced the Next.js loader").
+- **Keep the articles.** "the migration list", not "migration list". Telegraphic style reads as ambiguous.
+- **No slang, idiom, or filler.** No "basically", "just", "simply", "obviously", "magic", "hacky". If something is non-obvious, say what makes it non-obvious.
+- **Say the condition before the action.** "If the column is new, coerce it in every read path" is clearer than the reverse order.
+- **Spell out an acronym on first use** in a file, unless it is a proper name in the codebase (SQL, UTC, UI are fine).
+
+Technical names — identifiers, file paths, plugin names, SQL keywords — are always allowed and should be written exactly as they appear in the code.
+
+Good:
+
+```ts
+// The Z suffix parses as UTC, but getHours() reads back in local time.
+// The configured reset therefore shifts by the machine's UTC offset.
+```
+
+Avoid:
+
+```ts
+// NOTE: we basically just parse the time here — it's a bit of a hack but
+// timezone stuff is always messy so this was simply the easiest approach
+// that could possibly have been taken given the circumstances.
+```
+
+The same standard applies to commit messages, PR descriptions, and code review comments.
+
+## User-facing copy
+
+On-screen strings are ordinary product English, not Simplified Technical English — but keep them free of AI-sounding grammar. No em dashes in real copy (use a period or comma, or restructure), and no AI buzzwords (seamless, leverage, robust, elevate, unlock, empower, dive into, game-changer). This applies to strings a user reads, not to code comments. A `'—'` used as an empty-value placeholder in the UI is a display convention, not prose, and is fine.
 
 ## Conventions
 
-- **PR titles must follow Conventional Commits** (`<type>(<scope>): <subject>`, lowercase imperative subject) — the repo squash-merges PRs using the PR title as the commit message, so individual commit messages on a branch don't matter, only the PR title does. This is enforced by CI (`.github/workflows/conventional-commit-title.yml`); allowed types are `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
-- `npm run lint` intentionally keeps a minimal ESLint rule set (just `react-hooks/rules-of-hooks` + `exhaustive-deps`) to stay behavior-preserving with the pre-refactor Next.js setup and avoid flagging existing shadcn/ui code — see comments in `eslint.config.mjs` before adding stricter rules.
+- **PR titles must follow Conventional Commits.** `CONTRIBUTING.md` is the authoritative description — read it rather than relying on a summary here. The short version: the repo squash-merges using the PR title as the commit message, so only the PR title has to match `<type>(<scope>): <subject>`; commit messages on the branch are discarded. CI enforces it (`.github/workflows/conventional-commit-title.yml`), and editing the PR title re-runs the check with no push needed.
+- **ESLint is not as thin as it looks.** `eslint.config.mjs` layers `js.configs.recommended` and `tseslint.configs.recommended` underneath the two `react-hooks` rules, with two targeted opt-outs (`no-useless-assignment`, and `src/routeTree.gen.ts` ignored). The comments in that file explain that the rule set was chosen to stay behavior-preserving with the pre-refactor Next.js setup and to avoid flagging existing shadcn/ui code — read them before adding a stricter rule, and expect any new rule to light up vendored `components/ui/` files.
 - The app version is duplicated in `package.json` and `src-tauri/tauri.conf.json`; bump both together (see recent `chore: bump version to x.y.z` commits).
-- Every PR triggers `test-build.yml`, which does a full Tauri build matrix (macOS arm64/x86_64, Ubuntu, Windows) — a change that only builds on one platform will surface there.
+- Every PR triggers `test-build.yml`, which runs a full Tauri build matrix (macOS arm64/x86_64, Ubuntu, Windows). A change that only builds on one platform will surface there — Rust dependency and bundler changes are the usual culprits.
+
+## Finishing a piece of work
+
+- Run `npm run build` and `npm run lint` for anything touching TypeScript. Run `cargo check` in `src-tauri/` for anything touching Rust.
+- Exercise the change in `npm run tauri dev` when it touches the database, reset timers, or UI state — the type-checker cannot see those.
+- Update this file if you changed a convention it describes, and delete a rule here that stops being true. A stale rule is worse than a missing one, because an agent will spread it.
+- Leave no leftover git worktrees, scratch files, or debug output. A leftover worktree is a second full copy of the repo, so later searches return near-duplicate hits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+**This file is authoritative for every coding agent, not only Claude Code.** `AGENTS.md` exists for tools that look for that name, and it does nothing except point here. Keep it that way: when you change a convention, edit this file, and never copy a rule into `AGENTS.md`. Two copies drift, and the next agent follows the stale one.
+
 ## What this is
 
 chron is a Tauri 2 desktop app for tracking recurring reset-based tasks in video games (dailies/weeklies). The frontend is React 19 + TanStack Router (Vite build); the backend is a thin Rust shell (`src-tauri`) whose only real job is hosting a local SQLite database via `tauri-plugin-sql`. There is no server component — all state lives in the local `chron.db` SQLite file plus a little `localStorage` for UI settings.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+chron is a Tauri 2 desktop app for tracking recurring reset-based tasks in video games (dailies/weeklies). The frontend is React 19 + TanStack Router (Vite build); the backend is a thin Rust shell (`src-tauri`) whose only real job is hosting a local SQLite database via `tauri-plugin-sql`. There is no server component — all state lives in the local `chron.db` SQLite file plus a little `localStorage` for UI settings.
+
+## Commands
+
+```bash
+npm install          # install JS deps
+npm run dev           # vite dev server only (no Tauri window) — for pure frontend work
+npm run tauri dev     # full app: spawns vite dev server + opens the Tauri webview window
+npm run build          # tsc --noEmit type-check, then vite build (frontend only, outputs to dist/)
+npm run tauri build    # full desktop build (invokes the frontend build, then bundles a native binary)
+npm run lint            # eslint .
+npm run ui add <name>   # add/update a shadcn/ui component (npx shadcn@latest add ...)
+```
+
+There is no test suite in this repo (no `test` script, no test runner configured) — don't assume Vitest/Jest exists.
+
+Rust side (`src-tauri/`) can be checked directly with `cargo check` / `cargo build` from that directory if you're only touching Rust.
+
+## Architecture
+
+### Frontend/backend split
+
+- `src/`, `components/`, `lib/`, `hooks/` — the React app, bundled by Vite.
+- `src-tauri/` — the Rust shell. `src-tauri/src/lib.rs` is where the Tauri `Builder` is configured: plugins (`sql`, `shell`, `log`, `single-instance`) and the SQLite migration list live here. There is essentially no other Rust logic — all business logic lives in TypeScript.
+- The two are glued together by `src-tauri/tauri.conf.json` (`beforeDevCommand`/`beforeBuildCommand` run the npm scripts above) and by `@tauri-apps/plugin-*` JS APIs called from `lib/`.
+
+### Data layer
+
+- **Schema/migrations**: defined inline in `src-tauri/src/lib.rs` as a `Vec<Migration>` passed to `tauri_plugin_sql`. To change the schema, add a new migration with the next version number — don't edit an existing migration once it has shipped.
+- **Queries**: all SQL lives in `lib/database.ts`, which opens the db via `Database.load("sqlite:chron.db")` per call. There are two tables, `games` and `tasks` (one-to-many via `gameId`, `ON DELETE CASCADE`).
+- SQLite has no boolean type, so `games.open` and `tasks.done` are stored as `0`/`1` integers. Every read path in `database.ts` manually coerces these back to `boolean` (`!!game.open`) — remember to do the same for any new boolean column.
+- Domain types (`GameItem` in `lib/game.ts`, `TaskItem`/`TaskType` in `lib/task.ts`) are hand-maintained TS interfaces that mirror the SQL columns; they are not generated from the migrations. Zod validation schemas for the create/edit forms (`lib/zod.ts`, using zod v4's `error` callback API) are a **separate, manually-kept-in-sync** definition of roughly the same shape — update both when a field changes.
+
+### Reset-time logic
+
+`lib/timer.ts` computes daily/weekly reset windows. Key conventions:
+- `dailyTime` is always a string in `HH:mm:ss.sssZ` form (a JS Date time-string suffix), combined with today's date and parsed as UTC.
+- `weeklyDay` is 0–6 (JS `Date.getDay()`/`date-fns setDay` convention, i.e. 0 = Sunday).
+- Functions are pure and take the reset config in; they don't read from the DB or React state themselves.
+
+### React app structure
+
+- Routing is file-based via `@tanstack/react-router`'s Vite plugin: files under `src/routes/` are scanned and compiled into `src/routeTree.gen.ts`, which is **generated and gitignored** — never hand-edit it, and don't be surprised if it's missing before the first dev/build run. `src/routes/__root.tsx` defines the app shell (theme, sidebar, providers); `src/routes/index.tsx` is the dashboard; new pages are added by dropping a file in `src/routes/`.
+- The router uses **hash history** (`createHashHistory`), specifically so deep links survive under Tauri's custom asset protocol without extra Rust-side URL rewriting — don't switch this to browser history without checking that still holds.
+- Two app-level React contexts wrap everything in `__root.tsx`:
+  - `TimerProvider` (`components/chron/timer-context.tsx`) — ticks a shared `currentTimestamp` every second; use `useTimer()` instead of each component running its own interval.
+  - `SettingsProvider` (`components/chron/settings-context.tsx`) — wraps `GameSettings` (`lib/game-settings.ts`) in `localStorage` via `use-local-storage.tsx`.
+- `components/ui/` is shadcn/ui (new-york style, generated — see `components.json`); treat it as vendored and prefer adding new primitives via `npm run ui add` rather than hand-writing. `components/chron/` is app-specific composition on top of it (game cards, task lists, dialogs, sidebar).
+
+### Path aliases
+
+`@chron/*` resolves to the repo root (configured in both `tsconfig.json` paths and the Vite `resolve.alias`) — e.g. `@chron/lib/database`, `@chron/components/ui/button`. Use this instead of relative `../../..` imports.
+
+### Tauri capabilities
+
+Any new Tauri plugin/API surface used from the frontend needs a matching permission added to `src-tauri/capabilities/default.json`, or the call will fail at runtime with a permission error even though it type-checks.
+
+## Conventions
+
+- **PR titles must follow Conventional Commits** (`<type>(<scope>): <subject>`, lowercase imperative subject) — the repo squash-merges PRs using the PR title as the commit message, so individual commit messages on a branch don't matter, only the PR title does. This is enforced by CI (`.github/workflows/conventional-commit-title.yml`); allowed types are `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+- `npm run lint` intentionally keeps a minimal ESLint rule set (just `react-hooks/rules-of-hooks` + `exhaustive-deps`) to stay behavior-preserving with the pre-refactor Next.js setup and avoid flagging existing shadcn/ui code — see comments in `eslint.config.mjs` before adding stricter rules.
+- The app version is duplicated in `package.json` and `src-tauri/tauri.conf.json`; bump both together (see recent `chore: bump version to x.y.z` commits).
+- Every PR triggers `test-build.yml`, which does a full Tauri build matrix (macOS arm64/x86_64, Ubuntu, Windows) — a change that only builds on one platform will surface there.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,8 @@ Depending on how large the project is, you may want to outsource the questioning
 > ### Legal Notice <!-- omit in toc -->
 > When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
 
+**If you are an AI coding agent, read [`AGENTS.md`](./AGENTS.md) before you change any file.** It points you at [`CLAUDE.md`](./CLAUDE.md), which is the authoritative instruction file for this repository and documents several behaviors that are wrong to guess at. This applies whichever tool you run under. Contributors delegating work to an agent should make sure it has read those files.
+
 ### Reporting Bugs
 
 <!-- omit in toc -->


### PR DESCRIPTION
## Summary
Adds a `CLAUDE.md` at the repo root to give Claude Code (and other AI assistants) working guidance for this codebase: common commands, the Tauri/React architecture, data-layer conventions (SQLite migrations, boolean coercion, duplicated types/zod schemas), reset-time logic conventions, routing/context structure, and repo conventions (Conventional Commit PR titles, dual version bumps, CI build matrix).

No source code changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)