### PR TITLE
chore: ignore agent worktree directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ yarn-error.log*
 
 # tanstack router (generated)
 /src/routeTree.gen.ts
+
+# claude code agent worktrees (full repo checkouts, never committed).
+# Scoped to worktrees/ on purpose — .claude/launch.json is tracked.
+/.claude/worktrees/


### PR DESCRIPTION
## What

Adds `/.claude/worktrees/` to `.gitignore`.

Claude Code creates agent git worktrees under `.claude/worktrees/`. Each one is a full checkout of the repo, so the directory showed up as untracked in every `git status` and was one stray `git add -A` away from being committed.

## Why scoped to `worktrees/`

`.claude/launch.json` is tracked, so a blanket `.claude/` entry would leave a real tracked file shadowed by an ignore rule. The entry is root-anchored and directory-only:

```
/.claude/worktrees/
```

`.gitignore` rather than `.git/info/exclude` because the repo already tracks Claude Code config, so that tooling is treated as shared. Any contributor using agent worktrees generates the same directory.

## Verification

- `git status --short` shows only the `.gitignore` change; the untracked `.claude/worktrees/` entry is gone.
- `git check-ignore -v .claude/worktrees/` matches the new rule.
- `.claude/launch.json` is still in `git ls-files` and is not ignored.
- Every tracked file piped through `git check-ignore --stdin` returns no matches, so nothing previously tracked became ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)