### PR TITLE
fix(ui): correct stale shadcn config paths

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://ui.shadcn.com/schema.json",
   "style": "new-york",
-  "rsc": true,
+  "rsc": false,
   "tsx": true,
   "tailwind": {
-    "config": "tailwind.config.ts",
-    "css": "app/globals.css",
+    "config": "",
+    "css": "src/styles/globals.css",
     "baseColor": "zinc",
     "cssVariables": true,
     "prefix": ""


### PR DESCRIPTION
`components.json` still carried Next.js-era settings from before the Vite refactor (#41). All three were verified against the current tree before changing.

| Field | Before | After | Why |
|---|---|---|---|
| `rsc` | `true` | `false` | No React Server Components — this is a Vite + React 19 SPA inside Tauri. |
| `tailwind.config` | `"tailwind.config.ts"` | `""` | No such file. Tailwind v4 is configured via `@tailwindcss/postcss`; theme values live in `@theme` in the stylesheet. |
| `tailwind.css` | `"app/globals.css"` | `"src/styles/globals.css"` | There is no `app/` directory. |

## Verification

**`rsc`** — tested with `popover`, a client component (`badge` is inconclusive: shadcn emits no directive for purely presentational items regardless of the flag).

- With `rsc: true` → generated file began with `"use client"`.
- With `rsc: false` → no directive.

This matches the existing convention: every file already in `components/ui/` has zero `"use client"` directives, i.e. they were being stripped by hand.

**Paths** — confirmed absent: no `tailwind.config.*` anywhere in the repo, no `app/` directory. `postcss.config.mjs` loads `@tailwindcss/postcss`, and `src/styles/globals.css` opens with `@import 'tailwindcss'` and an `@theme` block.

**End-to-end** — `npm run ui -- add popover` under the fixed config produced `components/ui/popover.tsx`, correctly placed, importing via the `@chron/lib/utils` alias, with no stray directive. The test addition and its dependency changes were reverted; this PR touches `components.json` only.

## Notes

- The `css` path is not exercised by every `add` — the two components tested wrote no CSS variables, so the corrected path is verified by file existence rather than by a write. An attempt to force a CSS-writing case with `chart` stopped at an interactive prompt to overwrite the existing `card.tsx`, which I declined; nothing was clobbered.
- The commit is unsigned — GPG signing needs a TTY that the automation environment doesn't provide. Since PRs here are squash-merged, the commit that lands on `main` is signed by GitHub.

## Follow-up

The local `docs/add-claude-md` branch (not pushed) documents these three items as known traps under *"`components.json` is stale, so `npm run ui add` needs cleanup"*, ending with "Fixing `components.json` itself is a welcome small PR." If this merges, that section should be removed and the surrounding text reduced to a plain pointer to `components.json`. I left that branch untouched rather than editing work in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)